### PR TITLE
Add KICK handling

### DIFF
--- a/chatlib/src/main/java/io/mrarm/chatlib/dto/KickMessageInfo.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/dto/KickMessageInfo.java
@@ -1,0 +1,32 @@
+package io.mrarm.chatlib.dto;
+
+import java.util.Date;
+
+public class KickMessageInfo extends MessageInfo {
+
+    private String kickedNick;
+
+    public KickMessageInfo(MessageSenderInfo sender, Date date, String kickedNick, String message) {
+        super(sender, date, message, MessageType.KICK);
+        this.kickedNick = kickedNick;
+    }
+
+    public String getKickedNick() {
+        return kickedNick;
+    }
+
+    public static class Builder extends MessageInfo.Builder {
+
+        public Builder(MessageSenderInfo sender, String kickedNick, String message) {
+            messageInfo = new KickMessageInfo(sender, new Date(), kickedNick, message);
+        }
+
+        public KickMessageInfo build() {
+            KickMessageInfo ret = (KickMessageInfo) messageInfo;
+            messageInfo = null;
+            return ret;
+        }
+
+    }
+
+}

--- a/chatlib/src/main/java/io/mrarm/chatlib/dto/MessageInfo.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/dto/MessageInfo.java
@@ -6,7 +6,7 @@ public class MessageInfo {
 
     public enum MessageType {
         NORMAL(0), NOTICE(1), ME(2), JOIN(3), PART(4), QUIT(5), NICK_CHANGE(6), MODE(7), TOPIC(8),
-        DISCONNECT_WARNING(100);
+        KICK(9), DISCONNECT_WARNING(100);
 
         private final int intValue;
         MessageType(int i) {

--- a/chatlib/src/main/java/io/mrarm/chatlib/irc/CommandHandlerList.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/irc/CommandHandlerList.java
@@ -23,6 +23,7 @@ public class CommandHandlerList {
             defaultHandlers.registerHandler(new PingCommandHandler());
             defaultHandlers.registerHandler(new AwayCommandHandler());
             defaultHandlers.registerHandler(new TopicCommandHandler());
+            defaultHandlers.registerHandler(new KickCommandHandler());
         }
         handlers.putAll(defaultHandlers.handlers);
 

--- a/chatlib/src/main/java/io/mrarm/chatlib/irc/handlers/KickCommandHandler.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/irc/handlers/KickCommandHandler.java
@@ -1,0 +1,60 @@
+package io.mrarm.chatlib.irc.handlers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import io.mrarm.chatlib.NoSuchChannelException;
+import io.mrarm.chatlib.dto.KickMessageInfo;
+import io.mrarm.chatlib.dto.MessageSenderInfo;
+import io.mrarm.chatlib.irc.ChannelData;
+import io.mrarm.chatlib.irc.CommandHandler;
+import io.mrarm.chatlib.irc.InvalidMessageException;
+import io.mrarm.chatlib.irc.MessagePrefix;
+import io.mrarm.chatlib.irc.ServerConnectionData;
+
+public class KickCommandHandler implements CommandHandler {
+
+    @Override
+    public Object[] getHandledCommands() {
+        return new Object[]{"KICK"};
+    }
+
+    @Override
+    public void handle(ServerConnectionData connection, MessagePrefix sender, String command, List<String> params,
+                       Map<String, String> tags)
+            throws InvalidMessageException {
+        if (sender == null) {
+            // Apparently some broken IRCd or bouncers can send us messages without a prefix. We assume those are meant
+            // to be processed as our client.
+            sender = new MessagePrefix(connection.getUserNick());
+        }
+
+        String channel = CommandHandler.getParamWithCheck(params, 0);
+        String kicked = CommandHandler.getParamWithCheck(params, 1);
+        if (kicked.equalsIgnoreCase(connection.getUserNick())) {
+            connection.onChannelLeft(channel);
+        }
+        try {
+            UUID senderUUID = connection.getUserInfoApi().resolveUser(sender.getNick(), sender.getUser(),
+                    sender.getHost(), null, null).get();
+            UUID kickedUUID = connection.getUserInfoApi().resolveUser(kicked, null, null, null, null).get();
+            MessageSenderInfo senderInfo = new MessageSenderInfo(sender.getNick(), sender.getUser(), sender.getHost(),
+                    null, senderUUID);
+            String message = CommandHandler.getParamOrNull(params, 1);
+
+            ChannelData channelData = connection.getJoinedChannelData(channel);
+            ChannelData.Member member = channelData.getMember(kickedUUID);
+            if (member != null)
+                channelData.removeMember(member);
+            channelData.addMessage(new KickMessageInfo.Builder(senderInfo, kicked, message), tags);
+
+        } catch (NoSuchChannelException e) {
+            throw new InvalidMessageException("Invalid channel specified in a KICK message", e);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/chatlib/src/main/java/io/mrarm/chatlib/irc/handlers/KickCommandHandler.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/irc/handlers/KickCommandHandler.java
@@ -42,7 +42,7 @@ public class KickCommandHandler implements CommandHandler {
             UUID kickedUUID = connection.getUserInfoApi().resolveUser(kicked, null, null, null, null).get();
             MessageSenderInfo senderInfo = new MessageSenderInfo(sender.getNick(), sender.getUser(), sender.getHost(),
                     null, senderUUID);
-            String message = CommandHandler.getParamOrNull(params, 1);
+            String message = CommandHandler.getParamOrNull(params, 2);
 
             ChannelData channelData = connection.getJoinedChannelData(channel);
             ChannelData.Member member = channelData.getMember(kickedUUID);


### PR DESCRIPTION
First part of MCMrARM/revolution-irc#108 

Here I based the `KickMessageInfo` class off of `NickChangeMessageInfo`, and added what seemed like a reasonable handler. This class stores two extra strings: the kick target's nick, and the kick reason (stored in the general `message` field)