### PR TITLE
Set own nick from RPL_WELCOME

### DIFF
--- a/chatlib/src/main/java/io/mrarm/chatlib/irc/handlers/WelcomeCommandHandler.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/irc/handlers/WelcomeCommandHandler.java
@@ -30,6 +30,9 @@ public class WelcomeCommandHandler implements CommandHandler {
         int numeric = CommandHandler.toNumeric(command);
         StatusMessageInfo.MessageType type = StatusMessageInfo.MessageType.WELCOME_TEXT;
         switch (numeric) {
+            case RPL_WELCOME:
+                connection.setUserNick(CommandHandler.getParamWithCheck(params, 0));
+                break;
             case RPL_YOURHOST:
                 type = StatusMessageInfo.MessageType.YOUR_HOST_TEXT;
                 break;


### PR DESCRIPTION
When connecting to a bouncer whose current nick is not what we requested
during registration, getUserNick() will be wrong and break the JOIN
handler, for instance. Numeric replies are the most reliable source of
our own nick, so grab it from the first one we will receive.

**NOTE**: I'm not able to test this change.