### PR TITLE
explicitly show RPL_SASLSUCCESS (903) in status window

### DIFF
--- a/chatlib/src/main/java/io/mrarm/chatlib/dto/StatusMessageInfo.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/dto/StatusMessageInfo.java
@@ -7,7 +7,7 @@ public class StatusMessageInfo {
     public enum MessageType {
         NOTICE, MOTD, WELCOME_TEXT, YOUR_HOST_TEXT, SERVER_CREATED_TEXT, HOST_INFO, REDIR_TEXT,
         DISCONNECT_WARNING, UNHANDLED_MESSAGE, CTCP_PING, CTCP_VERSION,
-        WHOIS
+        WHOIS, SASL
     }
 
     private String sender;

--- a/chatlib/src/main/java/io/mrarm/chatlib/irc/cap/SASLCapability.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/irc/cap/SASLCapability.java
@@ -56,7 +56,7 @@ public class SASLCapability extends Capability {
             if (params.size() == 1 && CommandHandler.getParamWithCheck(params, 0).equals("+"))
                 continueAuthentication(connection);
         } else if (numeric == RPL_SASLSUCCESS) {
-            String message = CommandHandler.getParamWithCheck(params, 1, "SASL authentication successful");
+            String message = CommandHandler.getParamWithCheck(params, 1, null);
             connection.getServerStatusData().addMessage(new StatusMessageInfo(
                     sender != null ? sender.getServerName() : null, new Date(),
                     StatusMessageInfo.MessageType.SASL, message));

--- a/chatlib/src/main/java/io/mrarm/chatlib/irc/cap/SASLCapability.java
+++ b/chatlib/src/main/java/io/mrarm/chatlib/irc/cap/SASLCapability.java
@@ -1,5 +1,6 @@
 package io.mrarm.chatlib.irc.cap;
 
+import io.mrarm.chatlib.dto.StatusMessageInfo;
 import io.mrarm.chatlib.irc.CommandHandler;
 import io.mrarm.chatlib.irc.InvalidMessageException;
 import io.mrarm.chatlib.irc.MessagePrefix;
@@ -9,6 +10,7 @@ import io.mrarm.chatlib.util.Base64Util;
 import java.io.IOException;
 import java.security.InvalidParameterException;
 import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -54,6 +56,11 @@ public class SASLCapability extends Capability {
             if (params.size() == 1 && CommandHandler.getParamWithCheck(params, 0).equals("+"))
                 continueAuthentication(connection);
         } else if (numeric == RPL_SASLSUCCESS) {
+            String message = CommandHandler.getParamWithCheck(params, 1, "SASL authentication successful");
+            connection.getServerStatusData().addMessage(new StatusMessageInfo(
+                    sender != null ? sender.getServerName() : null, new Date(),
+                    StatusMessageInfo.MessageType.SASL, message));
+
             if (finishLock != -1) {
                 connection.getCapabilityManager().removeNegotationFinishLock(finishLock);
                 finishLock = -1;


### PR DESCRIPTION
`#freenode` gets a lot of people asking whether they successfully logged in via SASL or via some other means. This change will make it much more obvious than just printing `RPL_LOGGEDIN` (900)

**I am not able to test this change**
